### PR TITLE
Added code to avoid no matching results for search

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -14,6 +14,12 @@ class ListingsController < ApplicationController
       @listings = @listings.where("postcode ILIKE ?", "%#{params[:query]}%")
     end
 
+    if @listings.empty?
+      @not_found = true
+      @listings = Listing.all
+    end
+
+
     @listings = @listings.order(created_at: :desc)
   end
 

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -1,4 +1,6 @@
-
+<% if @not_found %>
+<h1> Sorry, We could not find any matching results. Please see below for all open listings on website</h1>
+<% end %>
 
 
  <div class="container">


### PR DESCRIPTION
- If search is pressed without any queries including dates, it will return all listings with a message for not found results